### PR TITLE
add opensuse kernel-default

### DIFF
--- a/.github/workflows/opensuse-default.yml
+++ b/.github/workflows/opensuse-default.yml
@@ -1,0 +1,45 @@
+on:
+  push:
+    tags:
+      - opensuse-default/*
+jobs:
+  build-opensuse-default:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - run: ./opensuse.sh
+        env:
+          # https://hub.docker.com/_/debian
+          DEBIAN_TAG: unstable-20250929
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opensuse-default
+          path: |
+            packages/BUILD/kernel-default-*-build/kernel-default-*/linux-*/*.deb
+            packages/BUILD/kernel-default-*-build/kernel-default-*/linux-*/linux-upstream_*.*
+  attest-opensuse-default:
+    runs-on: ubuntu-24.04
+    needs: build-opensuse-default
+    permissions:
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: opensuse-default
+          pattern: kernel-default-*-build/kernel-default-*/linux-*/linux-upstream_*.changes
+      - uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: kernel-default-*-build/kernel-default-*/linux-*/linux-upstream_*.changes
+  release-opensuse-default:
+    runs-on: ubuntu-24.04
+    needs: attest-opensuse-default
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: opensuse-default
+      - run: gh -R ${{ github.repository }} release create ${{ github.ref_name }} kernel-default-*-build/kernel-default-*/linux-*/*.deb kernel-default-*-build/kernel-default-*/linux-*/linux-upstream_*.*
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/opensuse.sh
+++ b/opensuse.sh
@@ -1,0 +1,26 @@
+#!/bin/sh -eux
+docker run --rm -i --platform linux/386 -v ./packages:/usr/src/packages opensuse/tumbleweed <<EOF
+zypper -n install rpm-build
+zypper addrepo http://download.opensuse.org/source/tumbleweed/repo/oss/ main-source
+zypper -n source-install kernel-source kernel-default
+rpmbuild -bf --target i586 /usr/src/packages/SPECS/kernel-default.spec
+EOF
+
+docker run --rm -i --platform linux/386 -v ./packages:/usr/src/packages debian:${DEBIAN_TAG:-unstable} <<EOF
+set -eux
+apt-get update
+apt-get install -y build-essential \
+	debhelper bc bison cpio flex kmod libdw-dev:native libelf-dev:native libssl-dev:native libssl-dev python3:native rsync \
+	gawk
+cd /usr/src/packages/BUILD/kernel-default-*-build/kernel-default-*/linux-*/linux-obj
+patch -p 0 -d .. <<'PATCH_EOF'
+--- Makefile.orig
++++ Makefile
+@@ -1203,3 +1203,3 @@
+ define filechk_suse_version
+-	\$(CONFIG_SHELL) \$(srctree)/scripts/gen-suse_version_h.sh
++	/bin/bash \$(srctree)/scripts/gen-suse_version_h.sh
+ endef
+PATCH_EOF
+make -j \$(nproc) bindeb-pkg
+EOF


### PR DESCRIPTION
here's openSUSE's kernel-default

this took disproportionately long to figure out how to get things set up for rpmbuild. actually is rpmbuild even a normal thing to do? everyone on the internet is talking about OBS instead

interesting things:
- kernel-default is a package that's "NoSource"
- the actual source is in kernel-source
- but don't install kernel-source, that puts the source all over the place where the kernel-default package won't look
- you need the _source_ of the kernel-source package 😵 
- rpmbuild doesn't care that it's from a 32 bit container image, it can tell, and it sets its target to 64 bit by default
- they're on linux 6.17 which has new build dependencies
- they add a gen-suse_version_h.sh script to the build. it's written for bash. it has a proper shebang specifying bash. but the makefile runs it with `$(CONFIG_SHELL)`, which is `sh`. and `sh` is dash on Debian. crashes. also their script doesn't have the execute bit set 🤨 
- they have `CONFIG_MODULE_COMPRESS_ZSTD=y`. gonna see if this fails to build or has problems booting