### PR TITLE
add slackware linux kernel-generic-smp

### DIFF
--- a/.github/workflows/slackware-generic-smp.yml
+++ b/.github/workflows/slackware-generic-smp.yml
@@ -1,0 +1,50 @@
+on:
+  push:
+    tags:
+      - slackware-generic-smp/*
+jobs:
+  build-slackware-generic-smp:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - run: ./slackware.sh
+        env:
+          # https://mirrors.slackware.com/slackware/slackware-15.0/patches/packages/
+          SLACKWARE_LINUX_KERNEL_SOURCE_PATH: slackware-15.0/patches/packages/linux-5.15.193/kernel-source-5.15.193_smp-noarch-1.txz
+          SLACKWARE_LINUX_CONFIG_PATH: slackware-15.0/patches/source/linux-5.15.193/kernel-configs/config-generic-smp-5.15.193-smp
+          SLACKWARE_LINUX_KERNEL_SOURCE_SHA256: 6b69dc20bf605da1983575c0f241e4fc26a7553d8eaed0b311e1e8ee434315ec
+          SLACKWARE_LINUX_CONFIG_SHA256: 7737da6607a6f11a6baafeb2fcc1bb88f8c0e660122d6594f76914316448e017
+          # https://hub.docker.com/_/debian
+          DEBIAN_TAG: unstable-20250929
+      - uses: actions/upload-artifact@v4
+        with:
+          name: slackware-generic-smp
+          path: |
+            slackware/kernel-source/usr/src/*.deb
+            slackware/kernel-source/usr/src/linux-upstream_*.*
+  attest-slackware-generic-smp:
+    runs-on: ubuntu-24.04
+    needs: build-slackware-generic-smp
+    permissions:
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: slackware-generic-smp
+          pattern: linux-upstream_*.changes
+      - uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: linux-upstream_*.changes
+  release-slackware-generic-smp:
+    runs-on: ubuntu-24.04
+    needs: attest-slackware-generic-smp
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v5
+        with:
+          name: slackware-generic-smp
+      - run: gh -R ${{ github.repository }} release create ${{ github.ref_name }} *.deb linux-upstream_*.*
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/slackware.sh
+++ b/slackware.sh
@@ -1,0 +1,33 @@
+#!/bin/sh -eux
+mkdir -p slackware
+curl -fL \
+	-o slackware/kernel-source.txz "https://mirrors.slackware.com/slackware/$SLACKWARE_LINUX_KERNEL_SOURCE_PATH" \
+	-o slackware/config "https://mirrors.slackware.com/slackware/$SLACKWARE_LINUX_CONFIG_PATH" \
+	-o slackware/linux-b3bee1e7c3f2b1b77182302c7b2131c804175870.patch 'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/patch/?id=b3bee1e7c3f2b1b77182302c7b2131c804175870'
+sha256sum -c <<EOF
+$SLACKWARE_LINUX_KERNEL_SOURCE_SHA256  slackware/kernel-source.txz
+$SLACKWARE_LINUX_CONFIG_SHA256  slackware/config
+2334c160fce0901263a9bdc44bead8caaeb87a97556643a798c21f94f9e40434  slackware/linux-b3bee1e7c3f2b1b77182302c7b2131c804175870.patch
+EOF
+
+docker run --rm -i --platform linux/i386 -v ./slackware:/root/slackware "debian:${DEBIAN_TAG:-unstable}" <<EOF
+set -eux
+apt-get update
+apt-get install -y build-essential \
+	bc rsync kmod cpio bison flex libssl-dev:native \
+	python3 libelf-dev
+cd /root/slackware
+mkdir kernel-source
+(
+	cd kernel-source
+	tar -xf ../kernel-source.txz
+	sh ./install/doinst.sh
+)
+patch -d kernel-source/usr/src/linux -p 1 <linux-b3bee1e7c3f2b1b77182302c7b2131c804175870.patch
+cp config kernel-source/usr/src/linux/.config
+(
+	cd kernel-source/usr/src/linux
+	make olddefconfig
+	make -j \$(nproc) bindeb-pkg
+)
+EOF


### PR DESCRIPTION
here's Slackware's linux kernel-generic-smp

interesting things:
- there's no docker image
- we're just doing the acquisition on the builder
- we're just checking integrity on some hashes that I am TOFU-ing
- they also have PGP signing for the kernel-source package (internally SHA-1)
- but I'm not using it 🤷 
- they also have a CHECKSUMS.md5 (with PGP signature) file that covers the config file
- but I'm not using it 🤷 
- they also have a kernel-generic.SlackBuild for automating the build
- but I'm not using it 🤷 
- they also have a build-all-kernels.sh for automating running kernel-generic.SlackBuild
- but I'm not using it 🤷 
- un- 🤷 , it's because it uses `make oldconfig` where we need `olddefconfig`
- because the compiler in Debian supports new features
- features that the config wants to ask about
- empirically the .config file that ships as part of the kernel-source package is the generic-smp i686 one we want
- but I'm getting a copy of that explicitly 🤷 
- we're just doing the configuration on Debian
- there's that `false` keyword collision too
- not a problem in Slackware itself, which ships GCC 11.2
- the Linux 5.15 lts branch doesn't have a patch for this
- the mainline patch to set a `-std=...` came in Linux 6.7
- it set it to gnu11, "for consistency with main kernel code"
- but back in Linux 5.15, the main kernel code was still using gnu89
- nonetheless, the patch cherry picks cleanly
- and it builds
- anachronistic though