### PR TITLE
adelie: use a mirror of packages repo

### DIFF
--- a/.github/workflows/adelie-easy.yml
+++ b/.github/workflows/adelie-easy.yml
@@ -9,6 +9,7 @@ jobs:
       - uses: actions/checkout@v5
       - run: ./adelie.sh
         env:
+          PACKAGES_REMOTE: https://github.com/wh0/adelie-packages.git
           # https://git.adelielinux.org/adelie/packages/-/tree/current/system/easy-kernel
           PACKAGES_COMMIT: 8d373cee60231d35782f34c4a9777d7fde352bf5
           # https://hub.docker.com/r/adelielinux/adelie

--- a/adelie.sh
+++ b/adelie.sh
@@ -2,7 +2,7 @@
 git init packages
 (
 	cd packages
-	git remote add origin https://git.adelielinux.org/adelie/packages.git
+	git remote add origin "${PACKAGES_REMOTE:-https://git.adelielinux.org/adelie/packages.git}"
 	git fetch origin "${PACKAGES_COMMIT:-current}" --depth 1
 	git checkout FETCH_HEAD
 )


### PR DESCRIPTION
Adélie Linux's host blocks the some Azure IPs (supposedly for an unrelated DDoS in the past). it has turned out to be a common occurrence for the hosted actions runners to be in this blocked range, with 7/8 attempts having failed. this PR switches the CI to use a mirror of the repo.

https://github.com/wh0/adelie-packages