### PR TITLE
adelie: use a mirror for apk

### DIFF
--- a/.github/workflows/adelie-easy.yml
+++ b/.github/workflows/adelie-easy.yml
@@ -14,6 +14,7 @@ jobs:
           PACKAGES_COMMIT: 8d373cee60231d35782f34c4a9777d7fde352bf5
           # https://hub.docker.com/r/adelielinux/adelie
           ADELIE_TAG: 1.0-beta6
+          ADELIE_MIRROR: https://plug-mirror.rcac.purdue.edu/adelie/adelie/current/system
           # https://hub.docker.com/_/debian
           DEBIAN_TAG: unstable-20251020
       - uses: actions/upload-artifact@v4

--- a/adelie.sh
+++ b/adelie.sh
@@ -20,6 +20,7 @@ EOF
 
 docker run --rm -i --platform linux/386 -v ./packages:/root/packages "adelielinux/adelie:${ADELIE_TAG:-latest}" <<EOF
 set -eux
+echo "${ADELIE_MIRROR:-https://distfiles.adelielinux.org/adelie/current/system}" >/etc/apk/repositories
 apk add build-tools
 cd /root/packages/system/easy-kernel
 newgrp abuild <<'NEWGRP_EOF'


### PR DESCRIPTION
in retrospect we should have known that the apk repository (which is also called a repository :thinking: ) is also hosted thusly