### PR TITLE
fix some nonfatal adelie problems

### DIFF
--- a/.github/workflows/adelie-easy.yml
+++ b/.github/workflows/adelie-easy.yml
@@ -14,6 +14,7 @@ jobs:
           PACKAGES_COMMIT: 8d373cee60231d35782f34c4a9777d7fde352bf5
           # https://hub.docker.com/r/adelielinux/adelie
           ADELIE_TAG: 1.0-beta6
+          # https://www.adelielinux.org/mirrors/
           ADELIE_MIRROR: https://plug-mirror.rcac.purdue.edu/adelie
           # https://hub.docker.com/_/debian
           DEBIAN_TAG: unstable-20251020

--- a/.github/workflows/adelie-easy.yml
+++ b/.github/workflows/adelie-easy.yml
@@ -16,6 +16,8 @@ jobs:
           ADELIE_TAG: 1.0-beta6
           # https://www.adelielinux.org/mirrors/
           ADELIE_MIRROR: https://plug-mirror.rcac.purdue.edu/adelie
+          # https://distfiles.adelielinux.org/source/archive/
+          DISTFILES_MIRROR: https://plug-mirror.rcac.purdue.edu/adelie/source/archive/easy-kernel-6.6.58-mc2-6.6.58
           # https://hub.docker.com/_/debian
           DEBIAN_TAG: unstable-20251020
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/adelie-easy.yml
+++ b/.github/workflows/adelie-easy.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           name: adelie-easy
           path: |
-            packages/system/easy-kernel/src/*.deb
-            packages/system/easy-kernel/src/linux-upstream_*.*
+            adelie-packages/system/easy-kernel/src/*.deb
+            adelie-packages/system/easy-kernel/src/linux-upstream_*.*
   attest-adelie-easy:
     runs-on: ubuntu-24.04
     needs: build-adelie-easy

--- a/.github/workflows/adelie-easy.yml
+++ b/.github/workflows/adelie-easy.yml
@@ -14,7 +14,7 @@ jobs:
           PACKAGES_COMMIT: 8d373cee60231d35782f34c4a9777d7fde352bf5
           # https://hub.docker.com/r/adelielinux/adelie
           ADELIE_TAG: 1.0-beta6
-          ADELIE_MIRROR: https://plug-mirror.rcac.purdue.edu/adelie/adelie/current/system
+          ADELIE_MIRROR: https://plug-mirror.rcac.purdue.edu/adelie
           # https://hub.docker.com/_/debian
           DEBIAN_TAG: unstable-20251020
       - uses: actions/upload-artifact@v4

--- a/adelie.sh
+++ b/adelie.sh
@@ -24,6 +24,7 @@ echo "${ADELIE_MIRROR:-https://distfiles.adelielinux.org}/adelie/current/system"
 apk add build-tools
 cd /root/adelie-packages/system/easy-kernel
 newgrp abuild <<'NEWGRP_EOF'
+set -eux
 abuild -Fr builddeps fetch unpack prepare
 NEWGRP_EOF
 EOF

--- a/adelie.sh
+++ b/adelie.sh
@@ -20,7 +20,7 @@ EOF
 
 docker run --rm -i --platform linux/386 -v ./adelie-packages:/root/adelie-packages "adelielinux/adelie:${ADELIE_TAG:-latest}" <<EOF
 set -eux
-echo "${ADELIE_MIRROR:-https://distfiles.adelielinux.org/adelie/current/system}" >/etc/apk/repositories
+echo "${ADELIE_MIRROR:-https://distfiles.adelielinux.org}/adelie/current/system" >/etc/apk/repositories
 apk add build-tools
 cd /root/adelie-packages/system/easy-kernel
 newgrp abuild <<'NEWGRP_EOF'

--- a/adelie.sh
+++ b/adelie.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -eux
-git init packages
+git init adelie-packages
 (
-	cd packages
+	cd adelie-packages
 	git remote add origin "${PACKAGES_REMOTE:-https://git.adelielinux.org/adelie/packages.git}"
 	git fetch origin "${PACKAGES_COMMIT:-current}" --depth 1
 	git checkout FETCH_HEAD
@@ -18,23 +18,23 @@ f7a77a8d94675934eff4a44a948e2d9450ca8f9d400fd02390c7dc58abef8ca8  patches/linux-
 758853dd061b1da26738a3237045d96c3a52193ed135a652c3e7c49731dccbb3  patches/linux-e5fe2d01dd97dae89656d227648b97301b2ad835.patch
 EOF
 
-docker run --rm -i --platform linux/386 -v ./packages:/root/packages "adelielinux/adelie:${ADELIE_TAG:-latest}" <<EOF
+docker run --rm -i --platform linux/386 -v ./adelie-packages:/root/adelie-packages "adelielinux/adelie:${ADELIE_TAG:-latest}" <<EOF
 set -eux
 echo "${ADELIE_MIRROR:-https://distfiles.adelielinux.org/adelie/current/system}" >/etc/apk/repositories
 apk add build-tools
-cd /root/packages/system/easy-kernel
+cd /root/adelie-packages/system/easy-kernel
 newgrp abuild <<'NEWGRP_EOF'
 abuild -Fr builddeps fetch unpack prepare
 NEWGRP_EOF
 EOF
 
-docker run --rm -i --platform linux/i386 -v ./packages:/root/packages -v ./patches:/root/patches "debian:${DEBIAN_TAG:-unstable}" <<EOF
+docker run --rm -i --platform linux/i386 -v ./adelie-packages:/root/adelie-packages -v ./patches:/root/patches "debian:${DEBIAN_TAG:-unstable}" <<EOF
 set -eux
 apt-get update
 apt-get install -y build-essential \
 	bc debhelper rsync kmod cpio bison flex libssl-dev:native \
 	lzop
-cd /root/packages/system/easy-kernel/src/linux-src
+cd /root/adelie-packages/system/easy-kernel/src/linux-src
 patch -p 1 </root/patches/linux-bc133e43cb565db50af64b4062889c99fa8541aa.patch
 patch -p 1 </root/patches/linux-b480d2b5dcc909a212ce614c187c6b463c043624.patch
 patch -p 1 </root/patches/linux-e5fe2d01dd97dae89656d227648b97301b2ad835.patch


### PR DESCRIPTION
- abuild was looking for something else in /root/packages. let's not confuse it further by checking out the packages repo there
- mirrors page list a certain URL but you'd need to set something different in ADELIE_MIRROR. fiddle with that...
- add a link to mirrors list page in case mirrors change someday
- newgrp loses xtrace and other flags, put in our usual `set ...`
- abuild fetch looks in default mirror, which is blocked, wastes a few seconds (thankfully not two minutes). set it to a mirror we can access. due to a quirk in the adelie mirror layout, we need to know the package name and version 😩 